### PR TITLE
update README.MD about JSON's prepare config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ prepare:
 {
   "prepare": [
     [
-      "semantic-release-ado",
+      "semantic-release-ionic-config",
       {
         "filenames": ["config.xml", "config.dev.xml", "config.prod.xml"]
       }


### PR DESCRIPTION
prevent misconfiguration that causes error by missing "semantic-release-ado". 